### PR TITLE
Ignore private files (starting with `-`) from being checked for filename-case

### DIFF
--- a/packages/eslint/src/configs/rules/base.js
+++ b/packages/eslint/src/configs/rules/base.js
@@ -23,7 +23,15 @@ export default [
         }
       ],
 
-      'unicorn/prevent-abbreviations': 'off'
+      'unicorn/prevent-abbreviations': 'off',
+
+      'unicorn/filename-case': [
+        'error',
+        {
+          case: 'kebabCase',
+          ignore: ['^-*']
+        }
+      ]
     }
   }
 ];


### PR DESCRIPTION
…ame-case