### PR TITLE
Update pnpm to v11 with security options

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
   "devDependencies": {
     "release-plan": "^0.18.0"
   },
-  "packageManager": "pnpm@10.34.3"
+  "packageManager": "pnpm@11.7.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+# config
 allowBuilds:
   esbuild: false
   core-js: false
@@ -39,9 +40,13 @@ minimumReleaseAgeExclude:
   - regjsparser@0.13.2
   - rollup@4.62.0
   - semver@7.8.4
+publicHoistPattern:
+  - "*stylelint*"
+
 packages:
   - packages/*
   - testing/*
+
 catalogs:
   build:
     "@babel/core": ^7.28.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,44 @@
+allowBuilds:
+  esbuild: false
+  core-js: false
+  unrs-resolver: false
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - eslint-plugin-unicorn@66.0.0
+  - "@ember/test-helpers@5.4.3"
+  - "@rollup/rollup-android-arm-eabi@4.62.0"
+  - "@rollup/rollup-android-arm64@4.62.0"
+  - "@rollup/rollup-darwin-arm64@4.62.0"
+  - "@rollup/rollup-darwin-x64@4.62.0"
+  - "@rollup/rollup-freebsd-arm64@4.62.0"
+  - "@rollup/rollup-freebsd-x64@4.62.0"
+  - "@rollup/rollup-linux-arm-gnueabihf@4.62.0"
+  - "@rollup/rollup-linux-arm-musleabihf@4.62.0"
+  - "@rollup/rollup-linux-arm64-gnu@4.62.0"
+  - "@rollup/rollup-linux-arm64-musl@4.62.0"
+  - "@rollup/rollup-linux-loong64-gnu@4.62.0"
+  - "@rollup/rollup-linux-loong64-musl@4.62.0"
+  - "@rollup/rollup-linux-ppc64-gnu@4.62.0"
+  - "@rollup/rollup-linux-ppc64-musl@4.62.0"
+  - "@rollup/rollup-linux-riscv64-gnu@4.62.0"
+  - "@rollup/rollup-linux-riscv64-musl@4.62.0"
+  - "@rollup/rollup-linux-s390x-gnu@4.62.0"
+  - "@rollup/rollup-linux-x64-gnu@4.62.0"
+  - "@rollup/rollup-linux-x64-musl@4.62.0"
+  - "@rollup/rollup-openbsd-x64@4.62.0"
+  - "@rollup/rollup-openharmony-arm64@4.62.0"
+  - "@rollup/rollup-win32-arm64-msvc@4.62.0"
+  - "@rollup/rollup-win32-ia32-msvc@4.62.0"
+  - "@rollup/rollup-win32-x64-gnu@4.62.0"
+  - "@rollup/rollup-win32-x64-msvc@4.62.0"
+  - baseline-browser-mapping@2.10.37
+  - caniuse-lite@1.0.30001799
+  - electron-to-chromium@1.5.372
+  - eslint-plugin-n@18.1.0
+  - eslint@10.5.0
+  - regjsparser@0.13.2
+  - rollup@4.62.0
+  - semver@7.8.4
 packages:
   - packages/*
   - testing/*


### PR DESCRIPTION
To improve defense against supply-chain attacks